### PR TITLE
Fix type-error issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,8 +43,8 @@ function Eventboss({ accountId, region, appName, environment, autoCreate, nameIn
                 }
                 receiveMessage(successHandler, errorHandler);
               })
-              .catch((error) => {
-                error(error);
+              .catch((err) => {
+                console.error(err);
                 setTimeout(() => {
                   receiveMessage(successHandler, errorHandler);
                 }, 20000);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eventboss",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Eventboss",
   "main": "index.js",
   "repository": "https://github.com/AirHelp/eventboss-js",


### PR DESCRIPTION
This change fixes the following issue:
```/usr/src/app/node_modules/eventboss/index.js:47                                                                                       │
│                 error(error);                                                                                                         │
│                 ^                                                                                                                     │
│                                                                                                                                       │
│ TypeError: error is not a function                                                                                                    │
│     at /usr/src/app/node_modules/eventboss/index.js:47:17                                                                             │
│     at processTicksAndRejections (node:internal/process/task_queues:96:5)
```